### PR TITLE
Add posibility of passing any cmd line option to autopep8

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -11,6 +11,12 @@ module.exports =
     maxLineLength:
       type: 'integer'
       default: 100
+    cmdLineOptions:
+      type: 'array'
+      default: []
+      description:
+          "Cmd line switches passed to autopep8 delimited by commas
+          (e.g. '-a, -a, --experimental')"
 
   activate: ->
     pi = new PythonAutopep8()

--- a/lib/python-autopep8.coffee
+++ b/lib/python-autopep8.coffee
@@ -45,7 +45,10 @@ class PythonAutopep8
 
     cmd = atom.config.get "python-autopep8.autopep8Path"
     maxLineLength = atom.config.get "python-autopep8.maxLineLength"
-    params = ["--max-line-length", maxLineLength, "-i", @getFilePath()]
+    cmdLineOptions = atom.config.get "python-autopep8.cmdLineOptions"
+    params = cmdLineOptions.concat [
+        "--max-line-length", maxLineLength, "-i", @getFilePath()
+    ]
 
     returnCode = process.spawnSync(cmd, params).status
     if returnCode != 0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "python-autopep8",
   "main": "./lib/index",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Format python code using autopep8",
   "repository": "https://github.com/markbaas/atom-python-autopep8",
   "license": "MIT",


### PR DESCRIPTION
I usually use autopep8 with some -a options to allow more aggressive formatting and AFAIK there was no way how to specify it. So I added it. 