### PR TITLE
Add configurable grammars 

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -13,7 +13,7 @@ module.exports =
       default: 100
     grammars:
       type: 'array'
-      default: ["Python"]
+      default: ["Python", "MagicPython"]
     cmdLineOptions:
       type: 'array'
       default: []

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -11,6 +11,9 @@ module.exports =
     maxLineLength:
       type: 'integer'
       default: 100
+    grammars:
+      type: 'array'
+      default: ["Python"]
     cmdLineOptions:
       type: 'array'
       default: []

--- a/lib/python-autopep8.coffee
+++ b/lib/python-autopep8.coffee
@@ -8,8 +8,9 @@ class PythonAutopep8
     editor = atom.workspace.getActiveTextEditor()
     if not editor?
       return false
-    grammar = editor.getGrammar().name
-    return grammar == 'Python' or grammar == 'MagicPython'
+    grammarNames = atom.config.get "python-autopep8.grammars"
+    grammarName = editor.getGrammar().name
+    return grammarName in grammarNames
 
   removeStatusbarItem: =>
     @statusBarTile?.destroy()
@@ -42,6 +43,7 @@ class PythonAutopep8
 
   format: ->
     if not @checkForPythonContext()
+      @updateStatusbarText("x", true)
       return
 
     cmd = atom.config.get "python-autopep8.autopep8Path"


### PR DESCRIPTION
Right now we can only use Python or MagicPython grammars; let's make it configurable! 

I've also added an "x" if we're not using the right grammar. When using this package for the first time I was confused when I tried to use the package and nothing happened (I was using the wrong grammar). 